### PR TITLE
feat: add server-manager skill - background dev server management

### DIFF
--- a/server-manager/README.md
+++ b/server-manager/README.md
@@ -1,0 +1,41 @@
+# Server Manager
+
+后台启动、追踪、关闭开发服务器，不阻塞 AI 对话。
+
+## 解决的问题
+
+在 AI 终端里运行 `npm run dev` 会一直占用终端，无法继续对话。本 skill 实现**完全不阻塞**的后台服务器管理。
+
+## 安装
+
+Skill 已包含所有脚本，直接使用：
+
+```powershell
+# 启动服务器
+start-server -Name "myapp" -Command "npm run dev" -Port 3000
+
+# 列出所有服务器
+list-servers
+
+# 健康检查
+health-server -Name "myapp"
+
+# 停止
+stop-server -Name "myapp"
+```
+
+## 支持的技术栈
+
+Node.js (Next.js / Vite / HyperFrames / Remotion / Motion Canvas)、Python (Streamlit / Flask / Django)、Go、Ruby、Rust 等任何开发服务器。
+
+## 命令
+
+| 命令 | 用途 |
+|------|------|
+| `start-server` | 启动服务器（不阻塞） |
+| `stop-server` | 停止单个服务器 |
+| `stop-all` | 停止所有服务器 |
+| `list-servers` | 列出活跃服务器 |
+| `health-server` | HTTP 健康检查 |
+| `tail-server` | 查看日志末尾 |
+| `grep-server` | 搜索日志关键词 |

--- a/server-manager/SKILL.md
+++ b/server-manager/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: server-manager
+description: 服务器进程管理技能。当用户需要启动开发服务器（npm run dev / streamlit run / python manage.py runserver 等）且不希望阻塞终端对话时触发，自动后台运行、追踪端口、记录日志。需要与 start-server / stop-server / list-servers / health-server / tail-server / grep-server 命令配合使用。适用于 Node.js (Vite/Next.js/HyperFrames/Remotion)、Python (Streamlit/Flask)、Go 等任意技术栈的开发服务器。
+---
+
+# Server Manager
+
+后台启动、追踪、关闭开发服务器，不阻塞 AI 对话。支持任意技术栈的服务器进程（Node.js、Python、Go、Rust 等）。
+
+## 核心问题
+
+AI 在终端里运行 `npm run dev` 时，命令会一直占用终端，导致无法继续对话。`Start-Process` 可以后台运行，但 AI 不知道它开了什么、端口是多少、什么时候能访问。
+
+## 设计原理
+
+```
+Start-Process cmd /c "$Command > $LogFile 2>&1"
+```
+
+启动命令通过 `cmd /c` 重定向到日志文件，实现**不阻塞**。同时记录端口和 PID 到 `.servers.json`，后续命令通过这个文件追踪所有服务器。
+
+## 启动服务器（核心命令）
+
+```powershell
+# 基础用法（自动检测端口）
+start-server -Name "myapp" -Command "npm run dev"
+
+# 指定端口
+start-server -Name "nextjs" -Command "npm run dev" -Port 3000
+
+# 指定工作目录
+start-server -Name "streamlit" -Command "streamlit run app.py" -Cwd "C:\project" -Port 8501
+```
+
+**参数说明：**
+
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `-Name` | ✅ | 服务器名称，唯一标识 |
+| `-Command` | ✅ | 完整启动命令 |
+| `-Port` | ❌ | 期望端口。不指定时自动检测 |
+| `-Cwd` | ❌ | 工作目录 |
+
+**成功输出：**
+```
+Started: nextjs port: 3000
+Log: C:\project\.server-logs\nextjs.log
+```
+
+**端口冲突处理：** 如果指定端口被占用，自动切换到下一个可用端口，不报错。
+
+---
+
+## 查询服务器列表
+
+```powershell
+# 列出所有通过 skill 启动的服务器
+list-servers
+
+# 示例输出：
+# nextjs     | port: 3000 | 5m | running | log: C:\..\nextjs.log
+# streamlit | port: 8501 | 15s | running
+```
+
+**功能：**
+- 显示所有活跃服务器及运行时间
+- 自动清理已崩溃/关闭的僵尸进程记录
+- 实时端口监听状态检测
+
+---
+
+## 健康检查
+
+```powershell
+# 检查服务器是否响应 HTTP 请求
+health-server -Name "nextjs"
+
+# 检查特定路径
+health-server -Name "nextjs" -Path "/api/health"
+
+# 自定义超时（秒）
+health-server -Name "nextjs" -TimeoutSec 10
+```
+
+**输出示例：**
+```
+OK  200  141ms  http://localhost:3000/
+DOWN  connection refused  http://localhost:3000/
+```
+
+**与端口检测的区别：** 端口在监听 ≠ 服务器正常响应。HTTP 健康检查能发现服务器卡死、接口报错等更真实的问题。
+
+---
+
+## 停止服务器
+
+```powershell
+# 停止单个服务器
+stop-server -Name "nextjs"
+
+# 停止所有服务器
+stop-all
+```
+
+**停止原理：** 通过端口查当前监听进程 → `Stop-Process -Force` 强制终止。
+
+---
+
+## 查看日志
+
+```powershell
+# 查看服务器日志末尾（默认20行）
+tail-server -Name "nextjs"
+
+# 查看更多行
+tail-server -Name "nextjs" -Lines 50
+```
+
+---
+
+## 日志搜索
+
+```powershell
+# 搜索包含关键词的行
+grep-server -Name "nextjs" -Pattern "error"
+
+# 按日志级别过滤（error/warn/info/debug）
+grep-server -Name "nextjs" -Level error
+
+# 组合：error级别中包含"port"的行，读最近200行
+grep-server -Name "nextjs" -Level error -Pattern "port" -Lines 200
+```
+
+**注意：** 日志文件在服务器启动时清空，每次重启后重新记录。`grep` 搜到的是"最后一次启动以来"的日志，不会翻到旧错误。
+
+---
+
+## 支持的技术栈
+
+| 技术栈 | 启动命令 | 默认端口 |
+|--------|----------|----------|
+| Next.js | `npm run dev` | 3000 |
+| Vite | `npm run dev` | 自动检测 |
+| HyperFrames | `npx hyperframes preview` | 3456 |
+| Remotion | `npm run dev` | 3000 |
+| Motion Canvas | `npm run template:dev` | 自动检测 |
+| Streamlit | `streamlit run app.py` | 8501 |
+| Flask | `flask run` | 5000 |
+| Django | `python manage.py runserver` | 8000 |
+| FastAPI | `uvicorn main:app` | 8000 |
+| Go HTTP | `go run .` | 自动检测 |
+
+**通用原则：** 任何启动后监听端口的开发服务器都支持。
+
+---
+
+## 文件结构
+
+```
+server-manager/
+├── SKILL.md              # 本文件
+├── README.md              # 使用文档
+└── scripts/
+    ├── start-server.ps1   # 启动服务器
+    ├── stop-server.ps1    # 停止单个服务器
+    ├── stop-all.ps1       # 停止所有服务器
+    ├── list-servers.ps1   # 列出服务器
+    ├── health-server.ps1  # HTTP 健康检查
+    ├── tail-server.ps1   # 查看日志末尾
+    └── grep-server.ps1    # 日志搜索
+```
+
+## 状态文件
+
+`.servers.json` 在 `start-server` 执行目录生成，记录所有活跃服务器：
+
+```json
+{
+  "servers": [
+    {
+      "name": "nextjs",
+      "port": 3000,
+      "pid": 12345,
+      "startedAt": "2026-04-24T10:00:00",
+      "logFile": "C:\\project\\.server-logs\\nextjs.log",
+      "command": "npm run dev"
+    }
+  ]
+}
+```
+
+## 注意事项
+
+1. **端口检测范围：** 自动检测仅覆盖 3000-9999，超出范围需手动指定 `-Port`
+2. **日志文件位置：** 默认在执行命令的目录下创建 `.server-logs/` 目录
+3. **停止机制：** 通过端口查到进程直接杀，不区分来源，可能误伤同名进程
+4. **Python 版本：** PowerShell 7+ 推荐，Windows PowerShell 5.1 兼容

--- a/server-manager/scripts/grep-server.ps1
+++ b/server-manager/scripts/grep-server.ps1
@@ -1,0 +1,75 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Name,
+    [string]$Pattern,
+    [ValidateSet("error","warn","info","debug","all")][string]$Level = "all",
+    [int]$Lines = 50
+)
+
+$stateFile = ".servers.json"
+if (-not (Test-Path $stateFile)) {
+    Write-Error "No servers tracked."
+    exit 1
+}
+
+$state = Get-Content $stateFile | ConvertFrom-Json
+$entry = $state.servers | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+
+if (-not $entry) {
+    Write-Error "Server '$Name' not found."
+    exit 1
+}
+
+$logFile = $entry.logFile
+if (-not (Test-Path $logFile)) {
+    Write-Error "Log file not found: $logFile"
+    exit 1
+}
+
+$levelPatterns = @{
+    error = '(?i)\b(error|err|fail|fatal)\b'
+    warn  = '(?i)\b(warn|warning)\b'
+    info  = '(?i)\b(info|notice)\b'
+    debug = '(?i)\b(debug|trace|verbose)\b'
+}
+
+$output = @()
+$rawOutput = Get-Content $logFile -Tail $Lines -ErrorAction SilentlyContinue
+
+if (-not $rawOutput) {
+    Write-Output "Log is empty."
+    exit 0
+}
+
+foreach ($line in $rawOutput) {
+    $match = $true
+
+    if ($Level -ne "all") {
+        $re = $levelPatterns[$Level]
+        if ($re -and $line -notmatch $re) {
+            $match = $false
+        }
+    }
+
+    if ($Pattern -and $match) {
+        if ($line -notmatch [regex]::Escape($Pattern)) {
+            $match = $false
+        }
+    }
+
+    if ($match) {
+        $output += $line
+    }
+}
+
+if ($output.Count -eq 0) {
+    $msg = "No matches"
+    if ($Level -ne "all") { $msg += " [$Level]" }
+    if ($Pattern) { $msg += " ""$Pattern""" }
+    $msg += " in last $Lines lines."
+    Write-Output $msg
+    exit 0
+}
+
+$count = $output.Count
+Write-Output "=== $count matches ==="
+$output | ForEach-Object { Write-Output $_ }

--- a/server-manager/scripts/health-server.ps1
+++ b/server-manager/scripts/health-server.ps1
@@ -1,0 +1,37 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Name,
+    [string]$Path = "/",
+    [int]$TimeoutSec = 3
+)
+
+$stateFile = ".servers.json"
+if (-not (Test-Path $stateFile)) {
+    Write-Error "No servers tracked."
+    exit 1
+}
+
+$state = Get-Content $stateFile | ConvertFrom-Json
+$entry = $state.servers | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+
+if (-not $entry) {
+    Write-Error "Server '$Name' not found."
+    exit 1
+}
+
+$port = $entry.port
+$url = "http://localhost:$port$Path"
+
+$start = Get-Date
+try {
+    $resp = Invoke-WebRequest -Uri $url -TimeoutSec $TimeoutSec -UseBasicParsing -ErrorAction Stop
+    $ms = [int]((Get-Date) - $start).TotalMilliseconds
+    $status = $resp.StatusCode
+    Write-Output "OK  $status  ${ms}ms  $url"
+} catch {
+    $msg = $_.Exception.Message
+    if ($msg -match "Unable to connect" -or $msg -match "connection refused" -or $msg -match "timeout") {
+        Write-Output "DOWN  connection refused  $url"
+    } else {
+        Write-Output "DOWN  $msg  $url"
+    }
+}

--- a/server-manager/scripts/list-servers.ps1
+++ b/server-manager/scripts/list-servers.ps1
@@ -1,0 +1,71 @@
+$ErrorActionPreference = "Stop"
+$stateFile = ".servers.json"
+$logDir = ".server-logs"
+
+if (Test-Path $stateFile) {
+    $state = Get-Content $stateFile | ConvertFrom-Json
+    $cleanServers = @()
+
+    foreach ($entry in $state.servers) {
+        $stillAlive = $false
+        if ($entry.port) {
+            $conn = Get-NetTCPConnection -LocalPort $entry.port -State Listen -ErrorAction SilentlyContinue
+            if ($conn) { $stillAlive = $true }
+        } elseif ($entry.pid) {
+            $proc = Get-Process -Id $entry.pid -ErrorAction SilentlyContinue
+            if ($proc) { $stillAlive = $true }
+        }
+
+        if ($stillAlive) {
+            $cleanServers += $entry
+        } else {
+            Write-Output "[cleaned] $($entry.name) (was port: $($entry.port))"
+        }
+    }
+
+    $state.servers = $cleanServers
+    $state | ConvertTo-Json -Depth 3 | Set-Content $stateFile -Encoding UTF8
+}
+
+if (-not (Test-Path $stateFile)) {
+    Write-Output "No servers tracked."
+    exit 0
+}
+
+$state = Get-Content $stateFile | ConvertFrom-Json
+if ($state.servers.Count -eq 0) {
+    Write-Output "No servers running."
+    exit 0
+}
+
+foreach ($entry in $state.servers) {
+    $status = "unknown"
+    $uptime = "-"
+    $logHint = ""
+
+    if ($entry.port) {
+        $conn = Get-NetTCPConnection -LocalPort $entry.port -State Listen -ErrorAction SilentlyContinue
+        if ($conn) {
+            $status = "running"
+            try {
+                $started = [DateTime]::Parse($entry.startedAt)
+                $span = (Get-Date) - $started
+                if ($span.TotalSeconds -lt 60) {
+                    $uptime = "$([int]$span.TotalSeconds)s"
+                } elseif ($span.TotalHours -lt 1) {
+                    $uptime = "$([int]$span.TotalMinutes)m"
+                } else {
+                    $uptime = "$([int]$span.TotalHours)h"
+                }
+            } catch {}
+        } else {
+            $status = "?? port $($entry.port) not listening"
+        }
+    }
+
+    if ($entry.logFile) {
+        $logHint = "| log: $($entry.logFile)"
+    }
+
+    Write-Output "$($entry.name) | port: $($entry.port) | $uptime | $status $logHint"
+}

--- a/server-manager/scripts/start-server.ps1
+++ b/server-manager/scripts/start-server.ps1
@@ -1,0 +1,115 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Name,
+    [Parameter(Mandatory=$true)][string]$Command,
+    [string]$Cwd,
+    [int]$Port
+)
+
+$ErrorActionPreference = "Continue"
+$stateFile = ".servers.json"
+$logDir = ".server-logs"
+
+if (-not (Test-Path $stateFile)) {
+    @{ servers = @() } | ConvertTo-Json -Depth 3 | Set-Content $stateFile -Encoding UTF8
+}
+
+$state = Get-Content $stateFile | ConvertFrom-Json
+
+if ($state.servers | Where-Object { $_.name -eq $Name }) {
+    Write-Error "Server '$Name' already tracked. Use 'stop-server $Name' first."
+    exit 1
+}
+
+if ($Cwd) {
+    $workDir = $Cwd
+} else {
+    $workDir = $PWD.Path
+}
+
+$logFile = Join-Path $workDir "$logDir\$Name.log"
+
+if (-not (Test-Path (Join-Path $workDir $logDir))) {
+    New-Item -ItemType Directory -Path (Join-Path $workDir $logDir) -Force | Out-Null
+}
+
+$timestamp = Get-Date -Format "o"
+
+$cmdArgs = "/c $Command > `"$logFile`" 2>&1"
+Start-Process cmd -ArgumentList $cmdArgs -WorkingDirectory $workDir -WindowStyle Hidden -PassThru | Out-Null
+
+$actualPort = $null
+$serverPid = $null
+$portNote = ""
+
+if ($Port) {
+    # Port was specified - check if it's already in use, auto-switch if needed
+    $occupied = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+    if ($occupied) {
+        $scannedPort = $Port + 1
+        while ($scannedPort -le 65535) {
+            $next = Get-NetTCPConnection -LocalPort $scannedPort -State Listen -ErrorAction SilentlyContinue
+            if (-not $next) {
+                $Port = $scannedPort
+                $portNote = " (port $scannedPort free, auto-switched from original port)"
+                break
+            }
+            $scannedPort++
+        }
+        if ($scannedPort -gt 65535) {
+            Write-Error "No available port found starting from $Port"
+            exit 1
+        }
+    }
+
+    # Wait for the (possibly switched) port to come up
+    $maxWait = 15
+    $waited = 0
+    while ($waited -lt $maxWait) {
+        Start-Sleep 1
+        $waited++
+        $conn = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+        if ($conn) {
+            $actualPort = $Port
+            $serverPid = $conn[0].OwningProcess
+            break
+        }
+    }
+
+    if (-not $actualPort) {
+        $portNote = " (port $Port not reached after ${maxWait}s, server may use different port)"
+    }
+} else {
+    # No port specified - capture existing ports, then detect NEW ones after startup
+    $existingPorts = @{}
+    Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue |
+        Where-Object { $_.LocalPort -ge 3000 -and $_.LocalPort -le 9999 } |
+        ForEach-Object { $existingPorts[$_.LocalPort] = $true }
+
+    Start-Sleep 2
+
+    $newConn = Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue |
+        Where-Object { $_.LocalPort -ge 3000 -and $_.LocalPort -le 9999 -and -not $existingPorts.ContainsKey($_.LocalPort) } |
+        Select-Object -First 1
+    if ($newConn) {
+        $actualPort = $newConn.LocalPort
+        $serverPid = $newConn.OwningProcess
+        $portNote = " (auto-detected port: $actualPort)"
+    }
+}
+
+$entry = @{
+    name = $Name
+    port = $actualPort
+    command = $Command
+    cwd = $workDir
+    pid = $serverPid
+    startedAt = $timestamp
+    logFile = $logFile
+}
+
+$state.servers += $entry
+$state | ConvertTo-Json -Depth 3 | Set-Content $stateFile -Encoding UTF8
+
+$portInfo = if ($actualPort) { "port: $actualPort" } else { "no port detected" }
+Write-Output "Started: $Name $portInfo$portNote"
+Write-Output "Log: $logFile"

--- a/server-manager/scripts/stop-all.ps1
+++ b/server-manager/scripts/stop-all.ps1
@@ -1,0 +1,29 @@
+$ErrorActionPreference = "Stop"
+$stateFile = ".servers.json"
+if (-not (Test-Path $stateFile)) {
+    Write-Output "No servers tracked."
+    exit 0
+}
+
+$state = Get-Content $stateFile | ConvertFrom-Json
+if ($state.servers.Count -eq 0) {
+    Write-Output "No servers running."
+    exit 0
+}
+
+foreach ($entry in $state.servers) {
+    if ($entry.port) {
+        $conn = Get-NetTCPConnection -LocalPort $entry.port -State Listen -ErrorAction SilentlyContinue
+        if ($conn) {
+            $killPid = $conn.OwningProcess | Select-Object -First 1
+            Stop-Process -Id $killPid -Force -ErrorAction SilentlyContinue
+        }
+    } elseif ($entry.pid) {
+        Stop-Process -Id $entry.pid -Force -ErrorAction SilentlyContinue
+    }
+    Write-Output "Stopped: $($entry.name)"
+}
+
+$state.servers = @()
+$state | ConvertTo-Json -Depth 3 | Set-Content $stateFile -Encoding UTF8
+Write-Output "All servers stopped."

--- a/server-manager/scripts/stop-server.ps1
+++ b/server-manager/scripts/stop-server.ps1
@@ -1,0 +1,33 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Name
+)
+
+$ErrorActionPreference = "Stop"
+$stateFile = ".servers.json"
+if (-not (Test-Path $stateFile)) {
+    Write-Error "No servers tracked."
+    exit 1
+}
+
+$state = Get-Content $stateFile | ConvertFrom-Json
+$entry = $state.servers | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+
+if (-not $entry) {
+    Write-Error "Server '$Name' not found in tracking."
+    exit 1
+}
+
+if ($entry.port) {
+    $conn = Get-NetTCPConnection -LocalPort $entry.port -State Listen -ErrorAction SilentlyContinue
+    if ($conn) {
+        $killPid = $conn.OwningProcess | Select-Object -First 1
+        Stop-Process -Id $killPid -Force -ErrorAction SilentlyContinue
+    }
+} elseif ($entry.pid) {
+    Stop-Process -Id $entry.pid -Force -ErrorAction SilentlyContinue
+}
+
+$state.servers = $state.servers | Where-Object { $_.name -ne $Name }
+$state | ConvertTo-Json -Depth 3 | Set-Content $stateFile -Encoding UTF8
+
+Write-Output "Stopped: $Name"

--- a/server-manager/scripts/tail-server.ps1
+++ b/server-manager/scripts/tail-server.ps1
@@ -1,0 +1,35 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Name,
+    [int]$Lines = 20
+)
+
+$stateFile = ".servers.json"
+if (-not (Test-Path $stateFile)) {
+    Write-Error "No servers tracked."
+    exit 1
+}
+
+$state = Get-Content $stateFile | ConvertFrom-Json
+$entry = $state.servers | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+
+if (-not $entry) {
+    Write-Error "Server '$Name' not found."
+    exit 1
+}
+
+$logFile = $entry.logFile
+if (-not $logFile) {
+    $logFile = ".server-logs\$Name.log"
+}
+
+if (-not (Test-Path $logFile)) {
+    Write-Output "No log file found: $logFile"
+    exit 0
+}
+
+$content = Get-Content $logFile -Tail $Lines -ErrorAction SilentlyContinue
+if (-not $content) {
+    Write-Output "Log is empty."
+} else {
+    $content | ForEach-Object { Write-Output $_ }
+}


### PR DESCRIPTION
## Summary

`server-manager` skill — 后台启动、追踪、关闭开发服务器，不阻塞 AI 对话。支持任意技术栈。

### 解决的问题

AI 在终端运行 `npm run dev` 时命令会一直占用终端，导致无法继续对话，本 skill 实现完全不阻塞的后台服务器管理。

### 核心命令

| 命令 | 用途 |
|------|------|
| `start-server` | 启动服务器（不阻塞，自动端口检测） |
| `stop-server` | 停止单个服务器 |
| `stop-all` | 停止所有服务器 |
| `list-servers` | 列出活跃服务器，自动清理僵尸进程 |
| `health-server` | HTTP 健康检查 |
| `tail-server` | 查看日志末尾 |
| `grep-server` | 日志关键词搜索 |

### 支持的技术栈

Node.js (Next.js / Vite / HyperFrames / Remotion / Motion Canvas)、Python (Streamlit / Flask / Django)、Go 等任意开发服务器。

### 设计原理

```powershell
Start-Process cmd /c "$Command > $LogFile 2>&1"
```

启动命令通过 `cmd /c` 重定向到日志文件实现不阻塞。端口和 PID 记录到 `.servers.json`，后续命令通过这个文件追踪所有服务器。

### 测试覆盖

已验证：HyperFrames (port 3456)、Remotion (port 3000)、Motion Canvas (port 9000)、Streamlit (port 8501)、Next.js (port 3000)