### PR TITLE
feat(videocut-subtitle): add optional Atlas STT backend

### DIFF
--- a/videocut-subtitle/SKILL.md
+++ b/videocut-subtitle/SKILL.md
@@ -2,7 +2,7 @@
 name: videocut-subtitle
 description: 字幕生成与烧录。转录→词典纠错→审核→烧录。触发词：加字幕、生成字幕、字幕
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   alias: "videocut:字幕"
 ---
 
@@ -42,6 +42,38 @@ whisper video.mp4 --model medium --language zh --output_format json
 | `large-v3` | 高精度，较慢 |
 
 输出 JSON 包含逐词时间戳，用于后续 SRT 生成。
+
+### 可选：Atlas Cloud 转录
+
+默认继续使用本地 Whisper，中文转录也必须保持该流程。只有用户明确选择 Atlas Cloud，且音频语言在 `xai/stt-v1` 当前支持列表内时，才使用仓库内置的 `scripts/atlas_transcribe.py`。输出保留 `words[].start` 和 `words[].end`，可继续用于后续文本审核和 SRT 时间戳匹配。
+
+先预览请求，不访问网络，也不会产生费用：
+
+```bash
+python3 videocut-subtitle/scripts/atlas_transcribe.py \
+  --input video.mp4 \
+  --language en \
+  --keyterm Claude \
+  --output transcript.json
+```
+
+用户确认参数后显式执行：
+
+```bash
+python3 videocut-subtitle/scripts/atlas_transcribe.py \
+  --input video.mp4 \
+  --language en \
+  --keyterm Claude \
+  --output transcript.json \
+  --execute
+```
+
+- 从环境变量 `ATLASCLOUD_API_KEY` 读取认证信息
+- `--language` 仅接受模型 schema 当前列出的语言代码；不支持中文，中文必须继续使用 Whisper
+- 本地文件最大 25 MiB；更大的媒体文件使用公开 HTTPS 地址配合 `--audio-url`
+- 可重复传入 `--keyterm`，将 `词典.txt` 中的专有词作为识别提示
+- 付费生成 POST 只提交一次，失败时不自动重试；仅结果 GET 使用有界退避
+- 默认不会覆盖已有输出，且输出路径必须位于当前工作目录内
 
 ---
 

--- a/videocut-subtitle/scripts/atlas_transcribe.py
+++ b/videocut-subtitle/scripts/atlas_transcribe.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Transcribe media with Atlas Cloud's xAI STT model."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable, Sequence
+from urllib.error import HTTPError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+
+BASE_URL = "https://api.atlascloud.ai/api/v1"
+MODEL = "xai/stt-v1"
+MAX_LOCAL_BYTES = 25 * 1024 * 1024
+RETRYABLE_GET_STATUS = {429, 500, 502, 503, 504}
+LANGUAGES = (
+    "ar",
+    "cs",
+    "da",
+    "nl",
+    "en",
+    "fil",
+    "fr",
+    "de",
+    "hi",
+    "id",
+    "it",
+    "ja",
+    "ko",
+    "mk",
+    "ms",
+    "fa",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "es",
+    "sv",
+    "th",
+    "tr",
+    "vi",
+)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Preview or execute an Atlas Cloud xAI STT request."
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input", type=Path, help="Local media file (up to 25 MiB)")
+    source.add_argument("--audio-url", help="Public HTTPS media URL")
+    parser.add_argument("--output", type=Path, default=Path("atlas-transcript.json"))
+    parser.add_argument("--language", choices=LANGUAGES)
+    parser.add_argument("--text-normalization", action="store_true")
+    parser.add_argument("--diarize", action="store_true")
+    parser.add_argument("--filler-words", action="store_true")
+    parser.add_argument("--keyterm", action="append", default=[])
+    parser.add_argument("--poll-attempts", type=int, default=60)
+    parser.add_argument("--poll-interval", type=float, default=2.0)
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Submit the billable request; without this flag the command only previews",
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_output(path: Path, root: Path | None = None) -> Path:
+    root = (root or Path.cwd()).resolve()
+    output = (root / path).resolve() if not path.is_absolute() else path.resolve()
+    try:
+        output.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("output must stay inside the current working directory") from exc
+    if output.exists():
+        raise FileExistsError(f"refusing to overwrite existing file: {output}")
+    return output
+
+
+def validate_args(args: argparse.Namespace) -> None:
+    if args.poll_attempts < 1 or args.poll_interval < 0:
+        raise ValueError("poll attempts must be positive and poll interval non-negative")
+    if args.text_normalization and not args.language:
+        raise ValueError("--text-normalization requires --language")
+    if len(args.keyterm) > 100:
+        raise ValueError("xai/stt-v1 accepts at most 100 key terms")
+    if any(not term or len(term) > 50 for term in args.keyterm):
+        raise ValueError("each key term must contain 1 to 50 characters")
+    if args.audio_url:
+        parsed = urlparse(args.audio_url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            raise ValueError("--audio-url must be a public HTTPS URL")
+        return
+    if not args.input.is_file():
+        raise ValueError(f"input file does not exist: {args.input}")
+    size = args.input.stat().st_size
+    if size == 0:
+        raise ValueError("input file must not be empty")
+    if size > MAX_LOCAL_BYTES:
+        raise ValueError("local input exceeds 25 MiB; use --audio-url for larger media")
+
+
+def audio_value(args: argparse.Namespace, preview: bool) -> str:
+    if args.audio_url:
+        return args.audio_url
+    size = args.input.stat().st_size
+    if preview:
+        return f"<base64 local file: {args.input.name} ({size} bytes)>"
+    return base64.b64encode(args.input.read_bytes()).decode("ascii")
+
+
+def build_payload(args: argparse.Namespace, preview: bool) -> dict[str, Any]:
+    validate_args(args)
+    payload: dict[str, Any] = {
+        "model": MODEL,
+        "audio": audio_value(args, preview),
+        "audio_format": "auto",
+        "text_normalization": args.text_normalization,
+        "diarize": args.diarize,
+        "filler_words": args.filler_words,
+        "keyterm": args.keyterm,
+    }
+    if args.language:
+        payload["language"] = args.language
+    return payload
+
+
+def decode_response(response: Any) -> dict[str, Any]:
+    payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise RuntimeError("Atlas Cloud returned a non-object response")
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise RuntimeError("Atlas Cloud response is missing a data object")
+    return data
+
+
+def submit_once(
+    payload: dict[str, Any], api_key: str, opener: Callable[..., Any]
+) -> str:
+    request = Request(
+        f"{BASE_URL}/model/generateAudio",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "videocut-atlas-stt/1.0",
+        },
+        method="POST",
+    )
+    with opener(request, timeout=60) as response:
+        prediction_id = decode_response(response).get("id")
+    if not isinstance(prediction_id, str) or not prediction_id:
+        raise RuntimeError("Atlas Cloud response is missing the prediction id")
+    return prediction_id
+
+
+def poll_prediction(
+    prediction_id: str,
+    api_key: str,
+    attempts: int,
+    interval: float,
+    opener: Callable[..., Any],
+    sleeper: Callable[[float], None],
+) -> dict[str, Any]:
+    url = f"{BASE_URL}/model/prediction/{prediction_id}"
+    for attempt in range(attempts):
+        request = Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "User-Agent": "videocut-atlas-stt/1.0",
+            },
+            method="GET",
+        )
+        try:
+            with opener(request, timeout=30) as response:
+                result = decode_response(response)
+        except HTTPError as exc:
+            if exc.code not in RETRYABLE_GET_STATUS or attempt == attempts - 1:
+                raise
+            sleeper(min(interval * (2**attempt), 30.0))
+            continue
+
+        status = result.get("status")
+        if status == "completed":
+            transcription = result.get("stt_result")
+            if not isinstance(transcription, dict) or not isinstance(
+                transcription.get("words"), list
+            ):
+                raise RuntimeError("completed prediction is missing word timestamps")
+            return transcription
+        if status in ("failed", "timeout"):
+            raise RuntimeError(
+                f"Atlas Cloud transcription failed: {result.get('error', status)}"
+            )
+        if attempt < attempts - 1:
+            sleeper(interval)
+    raise TimeoutError("Atlas Cloud transcription did not complete within the polling limit")
+
+
+def write_json_atomic(data: dict[str, Any], output: Path) -> int:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(data, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
+    fd, temporary = tempfile.mkstemp(prefix=f".{output.name}.", dir=output.parent)
+    try:
+        with os.fdopen(fd, "wb") as file_handle:
+            file_handle.write(encoded)
+            file_handle.flush()
+            os.fsync(file_handle.fileno())
+        os.link(temporary, output)
+        os.unlink(temporary)
+        return len(encoded)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def run(
+    argv: Sequence[str] | None = None,
+    opener: Callable[..., Any] = urlopen,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    args = parse_args(argv)
+    output = resolve_output(args.output)
+    preview_payload = build_payload(args, preview=True)
+    if not args.execute:
+        result = {
+            "mode": "preview",
+            "billable_request_sent": False,
+            "endpoint": f"{BASE_URL}/model/generateAudio",
+            "payload": preview_payload,
+            "output": str(output),
+        }
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return result
+
+    api_key = os.environ.get("ATLASCLOUD_API_KEY")
+    if not api_key:
+        raise RuntimeError("ATLASCLOUD_API_KEY is required with --execute")
+    payload = build_payload(args, preview=False)
+    prediction_id = submit_once(payload, api_key, opener)
+    transcription = poll_prediction(
+        prediction_id,
+        api_key,
+        args.poll_attempts,
+        args.poll_interval,
+        opener,
+        sleeper,
+    )
+    size = write_json_atomic(transcription, output)
+    result = {
+        "mode": "execute",
+        "model": MODEL,
+        "prediction_id": prediction_id,
+        "output": str(output),
+        "bytes": size,
+        "words": len(transcription["words"]),
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return result
+
+
+def main() -> int:
+    try:
+        run()
+    except (HTTPError, OSError, RuntimeError, TimeoutError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/videocut-subtitle/tests/test_atlas_transcribe.py
+++ b/videocut-subtitle/tests/test_atlas_transcribe.py
@@ -1,0 +1,150 @@
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+from urllib.error import HTTPError
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "atlas_transcribe.py"
+SPEC = importlib.util.spec_from_file_location("atlas_transcribe", SCRIPT)
+atlas_transcribe = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(atlas_transcribe)
+
+
+class FakeResponse:
+    def __init__(self, body):
+        self.body = json.dumps(body).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return self.body
+
+
+class AtlasTranscribeTests(unittest.TestCase):
+    def test_preview_uses_placeholder_without_network(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            media = root / "clip.mp4"
+            media.write_bytes(b"media")
+
+            def opener(*_args, **_kwargs):
+                raise AssertionError("preview must not access the network")
+
+            with patch.object(Path, "cwd", return_value=root), redirect_stdout(
+                io.StringIO()
+            ):
+                result = atlas_transcribe.run(
+                    ["--input", str(media)], opener=opener
+                )
+
+        self.assertEqual("preview", result["mode"])
+        self.assertFalse(result["billable_request_sent"])
+        self.assertEqual("<base64 local file: clip.mp4 (5 bytes)>", result["payload"]["audio"])
+
+    def test_submit_failure_is_not_retried(self):
+        requests = []
+
+        def opener(request, **_kwargs):
+            requests.append(request)
+            raise HTTPError(request.full_url, 503, "unavailable", {}, None)
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with patch.object(Path, "cwd", return_value=root), patch.dict(
+                os.environ, {"ATLASCLOUD_API_KEY": "test-key"}
+            ), self.assertRaises(HTTPError):
+                atlas_transcribe.run(
+                    ["--audio-url", "https://example.com/clip.mp4", "--execute"],
+                    opener=opener,
+                )
+
+        self.assertEqual(1, len(requests))
+        self.assertEqual("POST", requests[0].get_method())
+
+    def test_retryable_poll_error_retries_only_get_and_writes_words(self):
+        requests = []
+        responses = [
+            FakeResponse({"data": {"id": "pred-1"}}),
+            HTTPError("https://api.example/prediction", 503, "unavailable", {}, None),
+            FakeResponse(
+                {
+                    "data": {
+                        "status": "completed",
+                        "stt_result": {
+                            "text": "hello",
+                            "words": [{"text": "hello", "start": 0.1, "end": 0.5}],
+                        },
+                    }
+                }
+            ),
+        ]
+
+        def opener(request, **_kwargs):
+            requests.append(request)
+            response = responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "transcript.json"
+            with patch.object(Path, "cwd", return_value=root), patch.dict(
+                os.environ, {"ATLASCLOUD_API_KEY": "test-key"}
+            ), redirect_stdout(io.StringIO()):
+                result = atlas_transcribe.run(
+                    [
+                        "--audio-url",
+                        "https://example.com/clip.mp4",
+                        "--output",
+                        "transcript.json",
+                        "--poll-interval",
+                        "0",
+                        "--execute",
+                    ],
+                    opener=opener,
+                    sleeper=lambda _seconds: None,
+                )
+
+            saved = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(1, result["words"])
+        self.assertEqual("hello", saved["words"][0]["text"])
+        self.assertEqual(1, sum(request.get_method() == "POST" for request in requests))
+        self.assertEqual(2, sum(request.get_method() == "GET" for request in requests))
+
+    def test_output_must_be_new_and_inside_working_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            existing = root / "existing.json"
+            existing.write_text("{}", encoding="utf-8")
+            with self.assertRaises(FileExistsError):
+                atlas_transcribe.resolve_output(existing, root)
+            with self.assertRaises(ValueError):
+                atlas_transcribe.resolve_output(root.parent / "escape.json", root)
+
+    def test_text_normalization_requires_language(self):
+        args = atlas_transcribe.parse_args(
+            [
+                "--audio-url",
+                "https://example.com/clip.mp4",
+                "--text-normalization",
+            ]
+        )
+        with self.assertRaisesRegex(ValueError, "requires --language"):
+            atlas_transcribe.build_payload(args, preview=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更说明

- 保持本地 Whisper 为默认转录流程，中文仍强制使用 Whisper，避免能力回退
- 为模型支持的非中文语言新增显式可选的 Atlas Cloud `xai/stt-v1` 转录脚本
- 默认只预览请求；付费 POST 只提交一次，prediction GET 使用有界退避
- 保存 `stt_result.words` 的逐词时间戳，继续兼容字幕审核与 SRT 匹配流程
- 增加输出防覆盖、路径限制、keyterm 与 schema 参数校验

## 验证

- `python3 -m unittest discover -s videocut-subtitle/tests -v`：5 passed
- `python3 -m py_compile videocut-subtitle/scripts/atlas_transcribe.py videocut-subtitle/tests/test_atlas_transcribe.py`
- 零网络预览通过
- 单次真实 smoke POST 返回 `402 Payment Required`，未重试且未生成文件

## 兼容性说明

当前 `xai/stt-v1` schema 的语言枚举不含 `zh`。因此本改动没有把 Atlas 路径用于中文，并在 SKILL 中明确要求中文继续使用 Whisper。